### PR TITLE
配当推移タブを追加：全保有銘柄の総年間期待配当を週次記録

### DIFF
--- a/holding_calculator.py
+++ b/holding_calculator.py
@@ -24,7 +24,7 @@ def calculate_latest_holdings(
     df_latest_holdings = calculate_dividend_yield(
         codes=codes, sector_dict=holding_sector_dict
     )
-    df_latest_holdings.drop(columns=["配当利回り(%)", "URL"], inplace=True)
+    df_latest_holdings.drop(columns=["URL"], inplace=True)
 
     # 各銘柄の合計株数を計算
     df_latest_holdings["合計株数"] = 0

--- a/pick_high_yield_stock.py
+++ b/pick_high_yield_stock.py
@@ -87,6 +87,25 @@ if not df_holding.empty:
     # 並べ替えたデータを「時価総額」シートに書き込む
     update_worksheet_with_holdings(gc, spreadsheet_key, df_latest_holdings)
 
+    # 全保有銘柄の総年間配当を計算して「配当推移」シートに追記
+    total_annual_div = round(
+        (
+            df_latest_holdings["合計株数"]
+            * df_latest_holdings["株価"]
+            * df_latest_holdings["配当利回り(%)"]
+            / 100
+        ).sum()
+    )
+    total_market_cap = int(df_latest_holdings["時価総額"].sum())
+    record_date = datetime.today().strftime("%Y-%m-%d")
+    try:
+        ws_trend = gc.open_by_key(spreadsheet_key).worksheet("配当推移")
+    except gspread.exceptions.WorksheetNotFound:
+        sp = gc.open_by_key(spreadsheet_key)
+        ws_trend = sp.add_worksheet(title="配当推移", rows=500, cols=3)
+        ws_trend.append_row(["日付", "総年間配当(円)", "総時価総額(円)"])
+    ws_trend.append_row([record_date, total_annual_div, total_market_cap])
+
 
 # 最新の配当データを取得し、データフレームを作成
 high_dividend_codes, progressive_codes, consecutive_codes, sector_dict = (


### PR DESCRIPTION
## Summary

- `holding_calculator.py` で drop していた `配当利回り(%)` 列を保持するよう変更（1行）
- `pick_high_yield_stock.py` に、全保有銘柄の `合計株数×株価×配当利回り` を合計して Googleスプレッドシートの「配当推移」タブへ週次追記する処理を追加
- 「配当推移」タブが存在しない場合は自動作成

## Test plan

- [x] `python pick_high_yield_stock.py` を手動実行してエラーなく完了することを確認
- [x] Googleスプレッドシートの「配当推移」タブが新規作成され、`日付 / 総年間配当(円) / 総時価総額(円)` の1行が書き込まれていることを確認（2026-06-06: 17,995円 / 383,088円）

🤖 Generated with [Claude Code](https://claude.com/claude-code)