### PR TITLE
Stage3候補を「重複排除後の利回り上位10」に修正

### DIFF
--- a/stock_selector.py
+++ b/stock_selector.py
@@ -33,7 +33,9 @@ def pick_stock_in_holding_sector(df_stocks, df_latest_holdings):
     """
     対象銘柄の保有比率が高すぎない範囲で高配当銘柄を選定する。
     """
-    df_yield = df_stocks.head(10)
+    df_yield = df_stocks.head(20)
+    df_yield = df_yield.drop_duplicates(subset=["証券コード"], keep="first")
+    df_yield = df_yield.head(10)
     duplicate_codes = df_stocks["証券コード"].value_counts()
     duplicate_codes = duplicate_codes[duplicate_codes > 1]
     df_duplicates = df_stocks[df_stocks["証券コード"].isin(duplicate_codes.index)]


### PR DESCRIPTION
## 背景

銘柄選定の Stage 3（`pick_stock_in_holding_sector`）で、利回り上位の単一指数銘柄が候補から漏れる問題があった。実際に 2026-06-12 の自動選定では、利回り 4.95% の JFEホールディングス(5411) が候補に入らず、4.7% の丸井グループ(8252) が選定されていた。

## 原因

Stage 3 の `df_yield` が plain `head(10)`（**行ベース**）で、重複排除を concat 後に行っていた。上位10「行」に重複コード（例: テイ・エステック7313×2, UBE4208×2）が含まれると実質ユニーク数が10未満に減り、利回りユニーク9番目だった JFE が候補プールから漏れていた。

Stage 1（`pick_stock_by_yield`）は `head(20)→重複排除→head(10)` で正しくユニーク上位10を取れており、Stage 3 だけ実装が古いままだった。

## 修正

Stage 3 の `df_yield` を Stage 1 と同じ「重複排除してから上位10ユニーク」に揃えた。

```python
df_yield = df_stocks.head(20)
df_yield = df_yield.drop_duplicates(subset=["証券コード"], keep="first")
df_yield = df_yield.head(10)
```

## 検証

2026-06-12 の実データ（今週の銘柄・時価総額・購入履歴）で `select_stock` を再現実行：

- 修正前: ユニーク8銘柄しか評価されず → 丸井グループ(4.7%)
- 修正後: JFE がユニーク9番目として候補入り → **JFEホールディングス(4.95%)** が選定

JFE は未保有(own 0%)・鉄鋼セクター1.00%(<20%) のため両条件をクリアし、丸井より先に確定する。期待どおりの挙動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)