### PR TITLE
減配フィルタを追加：EDINET DBで来期減配予想の銘柄を選定候補から除外

### DIFF
--- a/edinet_dividend.py
+++ b/edinet_dividend.py
@@ -1,0 +1,136 @@
+import logging
+import os
+
+import requests
+from dotenv import load_dotenv
+
+logging.basicConfig(level=logging.ERROR, filename="error.log")
+
+load_dotenv(dotenv_path="/home/taru-boy/Desktop/get_stock/.env")
+
+BASE_URL = "https://edinetdb.jp/v1"
+API_KEY = os.getenv("EDINETDB_API_KEY")
+TIMEOUT = 20
+
+
+def _headers():
+    return {"X-API-Key": API_KEY}
+
+
+def build_code_map():
+    """
+    EDINET DBの全企業一覧を1リクエストで取得し、証券コード→EDINETコードの辞書を返す。
+
+    sec_codeは「4桁ティッカー+0」の5桁文字列（例: 三菱商事 8058 -> "80580"）。
+    本システムの証券コードは4桁なので、4桁キーで引けるようにする。
+
+    Returns:
+        dict: {"8058": "E02529", ...} 形式。取得失敗時は空辞書。
+    """
+    try:
+        r = requests.get(
+            f"{BASE_URL}/companies",
+            headers=_headers(),
+            params={"per_page": 5000},
+            timeout=TIMEOUT,
+        )
+        r.raise_for_status()
+        rows = r.json().get("data", [])
+    except (requests.RequestException, ValueError) as e:
+        logging.error(f"EDINET build_code_map failed: {e}")
+        return {}
+
+    code_map = {}
+    for row in rows:
+        sec_code = row.get("sec_code")
+        edinet_code = row.get("edinet_code")
+        if not sec_code or not edinet_code:
+            continue
+        # 5桁sec_code("80580")の先頭4桁を4桁ティッカーのキーにする
+        code_map[str(sec_code)[:4]] = edinet_code
+    return code_map
+
+
+# 一般的な株式分割比（forecast/actual がこれに近い場合は分割の可能性が高い）。
+# 予想配当が分割後ベースで開示されると raw 比較で誤って減配判定するため除外する。
+_SPLIT_RATIOS = (1 / 2, 1 / 3, 1 / 4, 1 / 5, 1 / 10)
+_SPLIT_TOLERANCE = 0.04
+
+
+def _looks_like_split(actual, forecast):
+    """
+    forecast/actual が一般的な分割比に近いなら、減配ではなく株式分割と見なす。
+    earnings には分割後ベースの予想配当が入ることがあり（adjusted forecastは無い）、
+    その場合 raw 比較すると実際は増配でも減配と誤判定するため。
+    """
+    if actual <= 0:
+        return False
+    ratio = forecast / actual
+    return any(abs(ratio - r) / r <= _SPLIT_TOLERANCE for r in _SPLIT_RATIOS)
+
+
+def _is_dividend_cut(edinet_code):
+    """
+    決算短信(earnings)から、来期配当予想が直近実績より減配かどうかを判定する。
+
+    earnings.dataは新しい順の配列。実績(dividend_per_share)と予想
+    (forecast_dividend_per_share)が両方non-nullの最新レコードで比較する。
+    予想が分割後ベースと推定される場合（_looks_like_split）は減配としない。
+
+    Returns:
+        bool: 減配ならTrue。判定不能・未開示・分割推定・エラー時はFalse（fail-open）。
+    """
+    try:
+        r = requests.get(
+            f"{BASE_URL}/companies/{edinet_code}/earnings",
+            headers=_headers(),
+            timeout=TIMEOUT,
+        )
+        r.raise_for_status()
+        earnings = r.json().get("data", {}).get("earnings", [])
+    except (requests.RequestException, ValueError) as e:
+        logging.error(f"EDINET earnings fetch failed for {edinet_code}: {e}")
+        return False
+
+    for record in earnings:
+        actual = record.get("dividend_per_share")
+        forecast = record.get("forecast_dividend_per_share")
+        if actual is None or forecast is None:
+            continue
+        if _looks_like_split(actual, forecast):
+            return False
+        return forecast < actual
+    return False
+
+
+def get_dividend_cut_codes(codes):
+    """
+    指定証券コードのうち、来期配当予想が減配の銘柄コードのset（文字列）を返す。
+
+    選定アルゴリズムが実際に評価する候補集合のみを渡すことを想定（レート節約）。
+    コード未解決・APIエラー・予想未開示の銘柄は除外せずスキップする（fail-open）。
+
+    Args:
+        codes (list): 証券コードのリスト（int/str混在可）
+
+    Returns:
+        set: 減配と判定された証券コードの集合（str）
+    """
+    if not API_KEY:
+        logging.error("EDINET get_dividend_cut_codes skipped: EDINETDB_API_KEY未設定")
+        return set()
+
+    code_map = build_code_map()
+    if not code_map:
+        return set()
+
+    cut_codes = set()
+    for code in codes:
+        code_str = str(code)
+        edinet_code = code_map.get(code_str)
+        if edinet_code is None:
+            logging.error(f"EDINET code unresolved: {code_str}")
+            continue
+        if _is_dividend_cut(edinet_code):
+            cut_codes.add(code_str)
+    return cut_codes

--- a/pick_high_yield_stock.py
+++ b/pick_high_yield_stock.py
@@ -15,7 +15,10 @@ from get_high_dividend_stock_code import get_high_dividend_stock_codes
 from holding_calculator import calculate_latest_holdings, get_holding_sector_dict
 
 # 銘柄選定関数をインポート
-from stock_selector import select_stock
+from stock_selector import candidate_codes, select_stock
+
+# 減配フィルタ（EDINET DB）をインポート
+from edinet_dividend import get_dividend_cut_codes
 
 # 最新の配当データフレームを作成する関数をインポート
 from watch_dividend import calculate_dividend_yield, create_latest_dividend_dataframe
@@ -128,8 +131,13 @@ worksheet.update(
 
 held_sector = df_holding["セクター"].unique()
 
+# 候補集合の来期減配予想銘柄を取得（候補集合のみ叩いてレート節約）
+cut_codes = get_dividend_cut_codes(candidate_codes(df_stocks))
+if cut_codes:
+    print(f"減配予想のため除外: {sorted(cut_codes)}")
+
 # 銘柄選定
-picked_stock = select_stock(df_stocks, df_latest_holdings, held_sector)
+picked_stock = select_stock(df_stocks, df_latest_holdings, held_sector, cut_codes)
 
 if picked_stock is not None:
     picked_code = picked_stock["証券コード"]

--- a/stock_selector.py
+++ b/stock_selector.py
@@ -1,22 +1,49 @@
 import pandas as pd
 
 
-def pick_stock_by_yield(df_stocks, held_sector):
+def candidate_codes(df_stocks):
+    """
+    選定アルゴリズムが実際に評価する候補銘柄の証券コードを返す。
+
+    「利回り上位20→重複排除→上位10」と「複数指数の重複銘柄」の和集合（重複排除）。
+    減配チェックのAPIリクエストをこの候補集合に限定するために使う。
+
+    Returns:
+        list: 証券コードのリスト（重複排除済み）
+    """
+    df_yield = df_stocks.head(20)
+    df_yield = df_yield.drop_duplicates(subset=["証券コード"], keep="first")
+    df_yield = df_yield.head(10)
+
+    duplicate_codes = df_stocks["証券コード"].value_counts()
+    duplicate_codes = duplicate_codes[duplicate_codes > 1]
+
+    codes = pd.concat(
+        [df_yield["証券コード"], pd.Series(duplicate_codes.index)], ignore_index=True
+    )
+    return list(codes.drop_duplicates())
+
+
+def pick_stock_by_yield(df_stocks, held_sector, cut_codes=frozenset()):
     """
     重複銘柄も考慮して、配当利回り上位10銘柄から未保有セクターの銘柄を選定する。
+    来期減配予想の銘柄は除外する。
     """
     df_yield = df_stocks.head(20)
     df_yield = df_yield.drop_duplicates(subset=["証券コード"], keep="first")
     df_yield = df_yield.head(10)
     for _, stock in df_yield.iterrows():
+        if str(stock["証券コード"]) in cut_codes:
+            continue
         if stock["セクター"] not in held_sector:
             return stock
     return None
 
 
-def pick_stock_by_duplicates(df_stocks, held_sector):
+def pick_stock_by_duplicates(df_stocks, held_sector, cut_codes=frozenset()):
     """
     複数指数に重複カウントされている銘柄から未保有セクターの銘柄を選定する。
+    来期減配予想の銘柄は除外する。
     """
     duplicate_codes = df_stocks["証券コード"].value_counts()
     duplicate_codes = duplicate_codes[duplicate_codes > 1]
@@ -24,14 +51,17 @@ def pick_stock_by_duplicates(df_stocks, held_sector):
     df_duplicates = df_duplicates.drop_duplicates(subset=["証券コード"], keep="first")
 
     for _, stock in df_duplicates.iterrows():
+        if str(stock["証券コード"]) in cut_codes:
+            continue
         if stock["セクター"] not in held_sector:
             return stock
     return None
 
 
-def pick_stock_in_holding_sector(df_stocks, df_latest_holdings):
+def pick_stock_in_holding_sector(df_stocks, df_latest_holdings, cut_codes=frozenset()):
     """
     対象銘柄の保有比率が高すぎない範囲で高配当銘柄を選定する。
+    来期減配予想の銘柄は除外する。
     """
     df_yield = df_stocks.head(20)
     df_yield = df_yield.drop_duplicates(subset=["証券コード"], keep="first")
@@ -47,6 +77,8 @@ def pick_stock_in_holding_sector(df_stocks, df_latest_holdings):
     for _, stock in temp_df.iterrows():
         sector = stock["セクター"]
         code = stock["証券コード"]
+        if str(code) in cut_codes:
+            continue
         stock_cap = df_latest_holdings[
             df_latest_holdings["証券コード"].astype(str) == str(code)
         ]["時価総額"].sum()
@@ -59,22 +91,23 @@ def pick_stock_in_holding_sector(df_stocks, df_latest_holdings):
     return None
 
 
-def select_stock(df_stocks, df_latest_holdings, held_sector):
+def select_stock(df_stocks, df_latest_holdings, held_sector, cut_codes=frozenset()):
     """
     銘柄選定のメイン処理。
+    cut_codes に含まれる証券コード（来期減配予想）は全段階で除外する。
     """
     # 配当利回り上位10銘柄から選定
-    stock = pick_stock_by_yield(df_stocks, held_sector)
+    stock = pick_stock_by_yield(df_stocks, held_sector, cut_codes)
     if stock is not None:
         return stock
 
     # 複数指数に重複カウントされている銘柄から選定
-    stock = pick_stock_by_duplicates(df_stocks, held_sector)
+    stock = pick_stock_by_duplicates(df_stocks, held_sector, cut_codes)
     if stock is not None:
         return stock
 
     # 保有済みセクターから高配当銘柄を選定
-    stock = pick_stock_in_holding_sector(df_stocks, df_latest_holdings)
+    stock = pick_stock_in_holding_sector(df_stocks, df_latest_holdings, cut_codes)
     if stock is not None:
         return stock
 


### PR DESCRIPTION
## 概要

高配当株選定に「来期配当予想が直近実績より減配の銘柄を買付候補から除外する」フィルタを追加。データ源は EDINET DB API（決算短信ベース）。株価不要の判定なのでスクレイピング不安定問題に依存しない、純粋な追加フィルタ。

## 変更点

- **`edinet_dividend.py`（新規）**
  - `build_code_map()`: `/v1/companies?per_page=5000` で全社の証券コード→EDINETコードを1回で解決
  - `get_dividend_cut_codes(codes)`: `/v1/companies/{edinet}/earnings` の `forecast_dividend_per_share` と `dividend_per_share` を比較し、減配予想の証券コード集合を返す
  - **株式分割ガード**: `forecast/actual` が一般的な分割比（1/2・1/3・1/4・1/5・1/10）に近い場合は分割と見なし除外しない（分割後ベースの予想による誤判定防止）
  - **fail-open**: APIエラー・キー未設定・予想未開示は除外せず続行し、週次cronを止めない
- **`stock_selector.py`**: `candidate_codes()` ヘルパ追加、3段階の各関数に `cut_codes` 引数を追加（アルゴリズム本体は不変）
- **`pick_high_yield_stock.py`**: `select_stock` 直前で候補集合のみAPIを叩いて `cut_codes` を渡す

## レート制限

一括マップ1回 + 候補ごとearnings 1回 ≈ 週20〜40リクエスト（無料枠100回/日に収まる）。`df_stocks`全件は叩かない。

## 検証（実API）

- 誤判定リスクだった三井住友トラスト(8309, 185→47.5の1:4分割) → 除外しない（正）
- 本物の減配 ブリヂストン(5108)・日本郵船(9101)・大和証券(8601) → 除外（正）
- 優良株(三菱商事8058, NTT9432) → 除外しない（正）
- 異常系（不正コード・キー空）→ 空set返却で例外を出さない（fail-open）

## 補足

- `EDINETDB_API_KEY` を `.env` に設定済み
- `CLAUDE.md` は `.gitignore` 対象のため本PRには含まれない（ローカルで更新済み）
- 既知の制約: 分割ガードは比率ヒューリスティックのため、ちょうど50%前後の本物の減配は分割と誤認して見逃す可能性あり（健全銘柄を誤除外しない方針を優先）

🤖 Generated with [Claude Code](https://claude.com/claude-code)