### PR TITLE
毎週2銘柄を選定するように変更

### DIFF
--- a/pick_high_yield_stock.py
+++ b/pick_high_yield_stock.py
@@ -15,7 +15,7 @@ from get_high_dividend_stock_code import get_high_dividend_stock_codes
 from holding_calculator import calculate_latest_holdings, get_holding_sector_dict
 
 # 銘柄選定関数をインポート
-from stock_selector import candidate_codes, select_stock
+from stock_selector import candidate_codes, select_stocks
 
 # 減配フィルタ（EDINET DB）をインポート
 from edinet_dividend import get_dividend_cut_codes
@@ -136,29 +136,31 @@ cut_codes = get_dividend_cut_codes(candidate_codes(df_stocks))
 if cut_codes:
     print(f"減配予想のため除外: {sorted(cut_codes)}")
 
-# 銘柄選定
-picked_stock = select_stock(df_stocks, df_latest_holdings, held_sector, cut_codes)
+# 銘柄選定（2銘柄）
+picked_stocks = select_stocks(df_stocks, df_latest_holdings, held_sector, cut_codes, n=2)
 
-if picked_stock is not None:
-    picked_code = picked_stock["証券コード"]
-    picked_name = picked_stock["会社名"]
-    picked_sector = picked_stock["セクター"]
-    picked_price = picked_stock["株価"]
-
-    # 購入履歴に追加
+if picked_stocks:
     today = datetime.today().strftime("%Y-%m-%d")
-    amount = math.ceil(10000 / picked_price)
     worksheet = gc.open_by_key(spreadsheet_key).worksheet("購入履歴")
-    worksheet.append_row(
-        [
-            str(today),
-            int(picked_code),
-            str(picked_name),
-            str(picked_sector),
-            float(picked_price),
-            int(amount),
-        ]
-    )
+    for picked_stock in picked_stocks:
+        picked_code = picked_stock["証券コード"]
+        picked_name = picked_stock["会社名"]
+        picked_sector = picked_stock["セクター"]
+        picked_price = picked_stock["株価"]
+
+        # 購入履歴に追加（1万円以上になるよう株数を切り上げ）
+        amount = math.ceil(10000 / picked_price)
+        worksheet.append_row(
+            [
+                str(today),
+                int(picked_code),
+                str(picked_name),
+                str(picked_sector),
+                float(picked_price),
+                int(amount),
+            ]
+        )
+    print(f"{len(picked_stocks)}銘柄を購入履歴に追記しました。")
 else:
     print("適切な銘柄が見つかりませんでした。")
 

--- a/stock_selector.py
+++ b/stock_selector.py
@@ -112,3 +112,23 @@ def select_stock(df_stocks, df_latest_holdings, held_sector, cut_codes=frozenset
         return stock
 
     return None
+
+
+def select_stocks(df_stocks, df_latest_holdings, held_sector,
+                  cut_codes=frozenset(), n=2):
+    """
+    select_stock を反復適用して最大 n 銘柄を選定する。
+    各回で選定済みコードを除外集合に、選定済みセクターを保有済みセクターに加え、
+    別セクター優先・コード重複回避を既存ロジックのまま実現する。
+    """
+    picked = []
+    held = set(held_sector)
+    excluded = set(cut_codes)
+    for _ in range(n):
+        stock = select_stock(df_stocks, df_latest_holdings, held, excluded)
+        if stock is None:
+            break
+        picked.append(stock)
+        excluded.add(str(stock["証券コード"]))
+        held.add(stock["セクター"])
+    return picked


### PR DESCRIPTION
## 概要
毎週「1銘柄」だけ選定していたのを「2銘柄」選定するように変更。それぞれ1万円以上で購入履歴に追記する。

## 変更内容
- `stock_selector.py`: 既存の `select_stock`（1銘柄選定）を反復適用する `select_stocks(n=2)` を追加。各回で選定済みコードを除外集合に・選定済みセクターを保有済みセクターに加えることで、別セクター優先・コード重複回避を既存ロジックのまま実現。
- `pick_high_yield_stock.py`: `select_stocks` を呼び、「購入履歴」シートに最大2行を追記（各銘柄 `math.ceil(10000 / 株価)` 株 = 1万円以上）。2銘柄見つからない場合は1銘柄のみのフォールバック。

## 検証
- 構文チェック通過。
- ダミーデータで `select_stocks` が別セクターの2銘柄を返すこと、コード重複が無いこと、候補1件のみのとき1要素を返すことを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)