### PR TITLE
減配フィルタ: 最新の実績×最新の予想で比較し分割調整後フィールドを使う

### DIFF
--- a/edinet_dividend.py
+++ b/edinet_dividend.py
@@ -69,13 +69,55 @@ def _looks_like_split(actual, forecast):
     return any(abs(ratio - r) / r <= _SPLIT_TOLERANCE for r in _SPLIT_RATIOS)
 
 
+def _latest_dividends(earnings):
+    """
+    新しい順のearnings配列から「最新の実績」「最新の予想」を別々に拾う。
+
+    実績と予想は別レコードに散らばっていてよい（本決算は両方持つが、四半期更新は
+    予想のみのことが多く、最新の本決算は配当未パースのこともある）。それぞれ独立に
+    新しい順で最初のnon-null値を採ることで、期中の予想修正を反映しstale化を防ぐ。
+
+    実績は分割調整後(adjusted_annual_dividend_per_share)を優先し、無ければ生値
+    (dividend_per_share)にフォールバックする。
+
+    判定は必ず `is None`（0.0＝無配予想/無配転落をfalsyで欠損扱いしないため）。
+
+    Returns:
+        tuple: (actual, forecast, actual_is_adjusted)。
+               見つからない側はNone。actual_is_adjustedは調整後実績を採れたか。
+    """
+    actual = None
+    actual_is_adjusted = False
+    forecast = None
+
+    for record in earnings:
+        if actual is None:
+            adjusted = record.get("adjusted_annual_dividend_per_share")
+            raw = record.get("dividend_per_share")
+            if adjusted is not None:
+                actual = adjusted
+                actual_is_adjusted = True
+            elif raw is not None:
+                actual = raw
+                actual_is_adjusted = False
+        if forecast is None:
+            f = record.get("forecast_dividend_per_share")
+            if f is not None:
+                forecast = f
+        if actual is not None and forecast is not None:
+            break
+
+    return actual, forecast, actual_is_adjusted
+
+
 def _is_dividend_cut(edinet_code):
     """
     決算短信(earnings)から、来期配当予想が直近実績より減配かどうかを判定する。
 
-    earnings.dataは新しい順の配列。実績(dividend_per_share)と予想
-    (forecast_dividend_per_share)が両方non-nullの最新レコードで比較する。
-    予想が分割後ベースと推定される場合（_looks_like_split）は減配としない。
+    earnings.dataは新しい順の配列。_latest_dividendsで最新の実績と予想を別々に
+    拾い比較する（当期通期予想は直近確定実績の翌期に一致しYoYで整合する）。
+    分割調整後の実績を採れた場合はそのまま比較し、生値にフォールバックした場合のみ
+    予想が分割後ベースと推定されるか（_looks_like_split）をチェックして誤検知を防ぐ。
 
     Returns:
         bool: 減配ならTrue。判定不能・未開示・分割推定・エラー時はFalse（fail-open）。
@@ -92,15 +134,12 @@ def _is_dividend_cut(edinet_code):
         logging.error(f"EDINET earnings fetch failed for {edinet_code}: {e}")
         return False
 
-    for record in earnings:
-        actual = record.get("dividend_per_share")
-        forecast = record.get("forecast_dividend_per_share")
-        if actual is None or forecast is None:
-            continue
-        if _looks_like_split(actual, forecast):
-            return False
-        return forecast < actual
-    return False
+    actual, forecast, actual_is_adjusted = _latest_dividends(earnings)
+    if actual is None or forecast is None:
+        return False
+    if not actual_is_adjusted and _looks_like_split(actual, forecast):
+        return False
+    return forecast < actual
 
 
 def get_dividend_cut_codes(codes):


### PR DESCRIPTION
## 背景

利回り1位のJFE（5411）が選定されずマツダ・マルイが選ばれた件を調査したところ、JFEは減配フィルタで**正しく除外**されていた（実績100円→来期予想80円＝▲20%の本物の減配）。フィルタ自体は今週は正しく機能していた。

ただし実データ（EDINET DB `earnings`）を精査した結果、`_is_dividend_cut` に2つの改善余地が判明したため対応する。

## 課題

1. **比較行のstale化（潜在バグ）**: 現行は「実績・予想が**両方**non-nullの最新行」に固定。最新の本決算が配当未パースだと最大1年前まで遡り、四半期更新（Q1〜Q3）は予想のみのため**期中の予想修正を無視**する。予想を上方修正していても古い予想で減配判定し続けるリスク。
2. **分割誤検知対策が弱い**: 比率ヒューリスティック `_looks_like_split` で推定していたが、実データには `adjusted_annual_dividend_per_share`（分割調整後の年間実績）があり、これを使う方が堅牢。

## 変更内容（`edinet_dividend.py` のみ）

- 純粋関数 `_latest_dividends(earnings)` を新設。新しい順に**実績と予想を別々に**最初のnon-null値で拾う（当期通期予想は直近確定実績の翌期に一致しYoYで整合）。
- 実績は `adjusted_annual_dividend_per_share`（分割調整後）を優先、無ければ生値にフォールバック。
- `_is_dividend_cut` を `_latest_dividends` ベースに書き換え。調整後実績を採れた場合はそのまま比較、生値フォールバック時のみ `_looks_like_split` ガードを残す。
- 判定はすべて `is None`（`0.0`＝無配転落を欠損扱いしない）。
- `_looks_like_split` は安全網として維持。呼び出し側・条件式の向き・fail-open方針・レート設計は不変。

## 検証

- **単体テスト（ネット不要・合成7ケース）**: 全PASS（期中上方修正→非減配 / 下方修正→減配 / 無配転落→減配 / 分割の調整後・ヒューリスティック両方→非減配 / JFE型→減配 / 予想未開示→fail-open）。
- **実データ（GET・3銘柄）**: `cut_codes={'5411'}` で JFEのみ除外・マルイ/マツダ非除外。今週の本番挙動と一致しリグレッション無し。

🤖 Generated with [Claude Code](https://claude.com/claude-code)